### PR TITLE
Fix Flakiness in testBindingToInterfaceWithExtraMethod_Bind()

### DIFF
--- a/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java
+++ b/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java
@@ -530,10 +530,24 @@ public class CheckedProviderTest extends TestCase {
       fail();
     } catch (CreationException expected) {
       assertEquals(
-          RemoteProviderWithExtraMethod.class.getName()
-              + " may not declare any new methods, but declared "
-              + RemoteProviderWithExtraMethod.class.getDeclaredMethods()[0].toGenericString(),
-          Iterables.getOnlyElement(expected.getErrorMessages()).getMessage());
+          Method firstMethod = RemoteProviderWithExtraMethod.class.getDeclaredMethods()[0];
+
+          List<String> exceptionTypes = Lists.newArrayList(
+              Arrays.stream(firstMethod.getExceptionTypes())
+                  .map(Class::getName)
+                  .iterator()
+          );
+  
+          String expectedStart = RemoteProviderWithExtraMethod.class.getName()
+              + " may not declare any new methods, but declared ";
+          String actualMessage = Iterables.getOnlyElement(expected.getErrorMessages()).getMessage();
+  
+          assertTrue("The message does not start as expected", actualMessage.startsWith(expectedStart));
+          assertTrue("The method name is not present in the message", actualMessage.contains(firstMethod.getName()));
+  
+          for (String exception : exceptionTypes) {
+              assertTrue("Missing exception type: " + exception, actualMessage.contains(exception));
+          }
     }
   }
 


### PR DESCRIPTION
This pull request addresses and fixes the flakiness observed in the `testBindingToInterfaceWithExtraMethod_Bind()` method. The problem with this test is that it expects `[java.rmi.RemoteException, java.net.BindException]` in the error message, but can also get `[java.net.BindExceptionjava.rmi.RemoteException]`, sometimes causing the test to fail, as it does not maintain the same order as expected. The flakiness of the test was detected using NonDex.

This is primarily caused by the `getDeclaredMethods()` API, as it does not guarantee the order of exceptions of a particular method. To address this issue, I created an `ArrayList` from the exceptions thrown by the first method of the `getDeclaredMethods()` API, checked whether the error message started as expected, and then individually checked whether the thrown exceptions match those found in the error message. 

This is more flexible and reliable compared to checking the whole error message at once, as the order of thrown exceptions may vary over several consecutive runs.